### PR TITLE
v0.15: Release CLI hardening

### DIFF
--- a/scripts/lib/publish.sh
+++ b/scripts/lib/publish.sh
@@ -79,6 +79,17 @@ publish_create_single() {
     local version="$2"
     local dry_run="${3:-true}"
 
+    # Check if release already exists
+    if gh release view "v${version}" --repo "homestak-dev/${repo}" &>/dev/null; then
+        if [[ "$dry_run" == "true" ]]; then
+            echo "    (release v${version} already exists, would skip)"
+        else
+            log_warn "Release v${version} already exists in ${repo}, skipping"
+            state_set_repo_field "$repo" "release" "done"
+        fi
+        return 0
+    fi
+
     local prerelease_flag=""
     if publish_is_prerelease "$version"; then
         prerelease_flag="--prerelease"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -304,6 +304,7 @@ cmd_validate() {
     local host="father"
     local skip=false
     local verbose=false
+    local remote=""
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -313,6 +314,10 @@ cmd_validate() {
                 ;;
             --host)
                 host="$2"
+                shift 2
+                ;;
+            --remote)
+                remote="$2"
                 shift 2
                 ;;
             --skip)
@@ -337,7 +342,7 @@ cmd_validate() {
 
     # Run validation
     local validation_passed=false
-    if run_validation "$scenario" "$host" "$skip" "$verbose"; then
+    if run_validation "$scenario" "$host" "$skip" "$verbose" "$remote"; then
         validation_passed=true
     fi
 
@@ -577,6 +582,7 @@ Options:
   --force            Override validation gate requirement
   --rollback         Rollback tags/releases on failure
   --skip             Skip validation (emergency releases only)
+  --remote HOST      Run validation on remote host via SSH
   --lines N          Number of audit log lines to show (default: 20)
 
 Examples:
@@ -584,6 +590,7 @@ Examples:
   release.sh status
   release.sh preflight
   release.sh validate --scenario vm-roundtrip --host father
+  release.sh validate --scenario vm-roundtrip --host father --remote father
   release.sh validate --skip
   release.sh tag --dry-run
   release.sh tag --execute


### PR DESCRIPTION
## Summary

Addresses dogfooding issues found during v0.14 release execution:

- **#40** - Add secrets decryption check to preflight
- **#39** - Add --remote flag to validate command  
- **#41** - Handle existing releases in publish command
- **#42** - Update verify to handle split packer images

## Changes

### Preflight secrets check (#40)
- Detects missing `site-config/secrets.yaml` before validation fails
- Shows clear remediation: `cd site-config && make decrypt`

### Remote validation (#39)
- `release.sh validate --remote <host>` runs validation via SSH
- Reports are copied back to local machine after execution

### Idempotent publish (#41)
- Checks if release exists before attempting to create
- Skips with warning instead of failing
- Enables safe re-runs of publish command

### Split file verification (#42)
- Recognizes `.partaa`/`.partab` files as valid uploads
- Shows part count in verification output (e.g., "debian-13-pve.qcow2 (2 parts)")

## Test plan

- [x] Preflight shows secrets status
- [x] Preflight fails with clear message when secrets.yaml missing
- [x] Publish dry-run shows "already exists" for v0.14 releases
- [x] Verify shows 3/3 assets with split file detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)