### PR TITLE
Add release tooling enhancements for v0.18

### DIFF
--- a/scripts/lib/tag.sh
+++ b/scripts/lib/tag.sh
@@ -144,6 +144,59 @@ tag_rollback_single() {
     state_set_repo_field "$repo" "tag" "rolled_back"
 }
 
+tag_reset_single() {
+    local repo="$1"
+    local version="$2"
+    local dry_run="${3:-true}"
+
+    local repo_path
+    if [[ "$repo" == "homestak-dev" ]]; then
+        repo_path="${WORKSPACE_DIR}"
+    else
+        repo_path="${WORKSPACE_DIR}/${repo}"
+    fi
+
+    local delete_local="git -C ${repo_path} tag -d v${version}"
+    local delete_remote="git -C ${repo_path} push origin :refs/tags/v${version}"
+    local create_tag="git -C ${repo_path} tag -a v${version} -m \"Release v${version}\""
+    local push_tag="git -C ${repo_path} push origin v${version}"
+
+    if [[ "$dry_run" == "true" ]]; then
+        echo "    ${delete_local}"
+        echo "    ${delete_remote}"
+        echo "    ${create_tag}"
+        echo "    ${push_tag}"
+        return 0
+    fi
+
+    # Delete local tag (may not exist)
+    audit_cmd "$delete_local (reset)" "git"
+    eval "$delete_local" 2>/dev/null || true
+
+    # Delete remote tag (may not exist)
+    audit_cmd "$delete_remote (reset)" "git"
+    eval "$delete_remote" 2>/dev/null || true
+
+    # Create new tag at HEAD
+    audit_cmd "$create_tag (reset)" "git"
+    if ! eval "$create_tag"; then
+        log_error "Failed to create tag in $repo"
+        return 1
+    fi
+
+    # Push new tag
+    audit_cmd "$push_tag (reset)" "git"
+    if ! eval "$push_tag"; then
+        log_error "Failed to push tag in $repo"
+        return 1
+    fi
+
+    # Update state
+    state_set_repo_field "$repo" "tag" "done"
+
+    return 0
+}
+
 # -----------------------------------------------------------------------------
 # Main Tag Runner
 # -----------------------------------------------------------------------------
@@ -293,6 +346,147 @@ run_tag_rollback() {
     echo "═══════════════════════════════════════════════════════════════"
     echo -e "  ROLLBACK COMPLETE"
     echo "═══════════════════════════════════════════════════════════════"
+    echo ""
+
+    return 0
+}
+
+run_tag_reset() {
+    local version="$1"
+    local dry_run="${2:-true}"
+    local target_repo="${3:-}"  # Empty = all repos
+
+    # Safety check: only allow reset for v0.x pre-releases
+    if [[ ! "$version" =~ ^0\. ]]; then
+        log_error "Tag reset is only allowed for v0.x pre-releases (got: v${version})"
+        log_error "For production releases, use proper versioning (e.g., v1.0.1)"
+        return 1
+    fi
+
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "  TAG RESET: v${version}"
+    if [[ -n "$target_repo" ]]; then
+        echo "  Scope: ${target_repo} only"
+    else
+        echo "  Scope: All ${#REPOS[@]} repos"
+    fi
+    if [[ "$dry_run" == "true" ]]; then
+        echo "  Mode: DRY-RUN (no changes will be made)"
+    else
+        echo "  Mode: EXECUTE"
+    fi
+    echo "═══════════════════════════════════════════════════════════════"
+    echo ""
+
+    # Validate target repo if specified
+    local repos_to_reset=()
+    if [[ -n "$target_repo" ]]; then
+        local found=false
+        for repo in "${REPOS[@]}"; do
+            if [[ "$repo" == "$target_repo" ]]; then
+                found=true
+                repos_to_reset+=("$repo")
+                break
+            fi
+        done
+        if [[ "$found" == "false" ]]; then
+            log_error "Unknown repo: $target_repo"
+            log_error "Valid repos: ${REPOS[*]}"
+            return 1
+        fi
+    else
+        repos_to_reset=("${REPOS[@]}")
+    fi
+
+    # Check repos have clean working trees
+    echo "Pre-conditions:"
+    local errors=()
+    for repo in "${repos_to_reset[@]}"; do
+        local repo_path
+        if [[ "$repo" == "homestak-dev" ]]; then
+            repo_path="${WORKSPACE_DIR}"
+        else
+            repo_path="${WORKSPACE_DIR}/${repo}"
+        fi
+
+        if [[ ! -d "$repo_path" ]]; then
+            errors+=("Repo not found: $repo")
+            continue
+        fi
+
+        local status
+        status=$(git -C "$repo_path" status --porcelain 2>/dev/null)
+        if [[ -n "$status" ]]; then
+            errors+=("Repo has uncommitted changes: $repo")
+        fi
+    done
+
+    if [[ ${#errors[@]} -gt 0 ]]; then
+        for err in "${errors[@]}"; do
+            echo -e "  ${RED}✗${NC} $err"
+        done
+        return 1
+    fi
+    echo -e "  ${GREEN}✓${NC} All target repos have clean working trees"
+    echo ""
+
+    if [[ "$dry_run" == "true" ]]; then
+        echo "Commands that would be executed:"
+        echo ""
+        for repo in "${repos_to_reset[@]}"; do
+            echo "  ${repo}:"
+            tag_reset_single "$repo" "$version" "true"
+            echo ""
+        done
+
+        echo "═══════════════════════════════════════════════════════════════"
+        echo "  DRY-RUN COMPLETE - No changes made"
+        echo "  Run with --execute to reset tags"
+        echo "═══════════════════════════════════════════════════════════════"
+        echo ""
+        return 0
+    fi
+
+    # Confirmation prompt for execute mode
+    echo "═══════════════════════════════════════════════════════════════"
+    echo -e "  ${YELLOW}WARNING: This will DELETE and RECREATE tags at HEAD${NC}"
+    echo -e "  ${YELLOW}This CANNOT be undone if others have pulled the tags${NC}"
+    echo "═══════════════════════════════════════════════════════════════"
+    echo ""
+    read -p "Type 'yes' to proceed, or Ctrl+C to abort: " -r
+    if [[ "$REPLY" != "yes" ]]; then
+        log_info "Aborted by user"
+        return 1
+    fi
+    echo ""
+
+    # Execute tag reset
+    local failed=false
+    for repo in "${repos_to_reset[@]}"; do
+        echo -n "  Resetting tag in ${repo}... "
+        if tag_reset_single "$repo" "$version" "false"; then
+            echo -e "${GREEN}done${NC}"
+        else
+            echo -e "${RED}FAILED${NC}"
+            failed=true
+        fi
+    done
+
+    echo ""
+    if [[ "$failed" == "true" ]]; then
+        echo "═══════════════════════════════════════════════════════════════"
+        echo -e "  RESULT: ${YELLOW}PARTIAL${NC}"
+        echo "  Some repos failed - check output above"
+        echo "═══════════════════════════════════════════════════════════════"
+        return 1
+    else
+        echo "═══════════════════════════════════════════════════════════════"
+        echo -e "  RESULT: ${GREEN}SUCCESS${NC}"
+        echo "  Tags reset to HEAD: v${version} in ${#repos_to_reset[@]} repos"
+        echo "═══════════════════════════════════════════════════════════════"
+        audit_log "TAG_RESET" "cli" "Tags v${version} reset in ${#repos_to_reset[@]} repos"
+    fi
     echo ""
 
     return 0


### PR DESCRIPTION
## Summary

- Add tag inventory check to `verify.sh` - verifies all 9 repos have expected tag
- Add tag reset/move capability to `tag.sh` - delete and recreate tags at HEAD (v0.x only)
- Add packer automation to `publish.sh`:
  - Detect template changes between releases
  - Copy images from previous release when unchanged
- Add `release.sh packer` command for image management
- Add `release.sh full` command for end-to-end release workflow
- Add SHA256SUMS to expected packer assets

## Test plan

- [ ] `release.sh init --version 0.18` initializes state
- [ ] `release.sh packer --check` detects template changes
- [ ] `release.sh tag --reset --dry-run` shows preview
- [ ] `release.sh full --dry-run` shows all phases
- [ ] `release.sh verify --version 0.17` shows tag inventory

Implements: #34, #48, #49, #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)