### PR TITLE
Add SHA256SUMS generation to packer --copy (#62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ All notable changes to this project will be documented in this file.
   - Exercises all commands in dry-run mode
   - Catches bugs before release (like v0.18's `gh release list --json` issue)
   - Supports `--verbose` for detailed output
+- `release.sh packer --copy` now generates SHA256SUMS (#62)
+  - Downloads images from source release
+  - Generates fresh SHA256SUMS after copy
+  - Uploads images + SHA256SUMS to target release
+  - Works even if source release predates checksum feature (v0.17)
 
 ## [v0.18] - 2026-01-13
 


### PR DESCRIPTION
## Summary

Enhance `release.sh packer --copy` to generate fresh SHA256SUMS after copying images.

## Changes

- Download only image files from source release (exclude existing SHA256SUMS)
- Generate fresh SHA256SUMS from downloaded images using `sha256sum *.qcow2`
- Upload both images and generated SHA256SUMS to target release

## Why

v0.17 and earlier releases predate the checksum feature (#22 in v0.18). When copying images from these older releases, we need to generate checksums rather than assume they exist.

## Dry-run Output

```
    gh release download v0.17 --repo homestak-dev/packer --pattern "debian-12-custom.qcow2" --dir "/tmp/xxx"
    gh release download v0.17 --repo homestak-dev/packer --pattern "debian-13-custom.qcow2" --dir "/tmp/xxx"
    gh release download v0.17 --repo homestak-dev/packer --pattern "debian-13-pve.qcow2" --dir "/tmp/xxx"
    cd "/tmp/xxx" && sha256sum *.qcow2 > SHA256SUMS 2>/dev/null || true
    gh release upload v0.19 "/tmp/xxx/debian-12-custom.qcow2" --repo homestak-dev/packer --clobber
    gh release upload v0.19 "/tmp/xxx/debian-13-custom.qcow2" --repo homestak-dev/packer --clobber
    gh release upload v0.19 "/tmp/xxx/debian-13-pve.qcow2" --repo homestak-dev/packer --clobber
    gh release upload v0.19 "/tmp/xxx/SHA256SUMS" --repo homestak-dev/packer --clobber
```

## Test plan

- [ ] `release.sh packer --copy --dry-run` shows SHA256SUMS generation step
- [ ] `release.sh packer --copy --execute` successfully uploads SHA256SUMS
- [ ] Verify downloaded SHA256SUMS matches actual checksums

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)