### PR TITLE
Document validation host prerequisites (#63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ All notable changes to this project will be documented in this file.
   - Uploads images + SHA256SUMS to target release
   - Works even if source release predates checksum feature (v0.17)
 
+### Documentation
+- Add validation host prerequisites section to RELEASE.md (#63)
+  - Documents what makes a host "validation-ready" beyond bootstrap
+  - Includes quick check script and common issues table
+  - Prerequisites: node config, API token, packer images, nested virt
+
 ## [v0.18] - 2026-01-13
 
 ### Theme: Release Tooling Completion


### PR DESCRIPTION
## Summary

Add documentation for what makes a host "validation-ready" beyond just being bootstrapped.

## Background

During v0.18 release, we discovered that bootstrap alone is insufficient for validation. A host needs additional configuration:
- Node configuration file
- API token configured
- Packer images available
- Nested virtualization enabled

## Changes

Added new section "Validation Host Prerequisites" to RELEASE.md Phase 3:

- Prerequisites table with setup commands
- Quick check shell script
- Common issues troubleshooting table

## Documentation Preview

| Prerequisite | Description | Setup Command |
|--------------|-------------|---------------|
| **Node configuration** | `site-config/nodes/{hostname}.yaml` must exist | `make node-config` |
| **API token** | Token in secrets.yaml | `pveum user token add...` |
| **Secrets decrypted** | secrets.yaml must be decrypted | `make decrypt` |
| **Packer images** | Images in local PVE storage | `./publish.sh` |
| **Nested virtualization** | For nested-pve scenarios | Check kvm_intel |

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)