### PR TITLE
feat: Add --packer-release flag to release.sh validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased] - v0.20
+## [Unreleased] - v0.21
+
+### Added
+- `release.sh validate --packer-release` flag for specifying packer image version (#74)
+  - Passes through to iac-driver's `--packer-release` option
+  - Enables validation with specific packer release when `latest` tag points to draft
+
+---
+
+## [v0.20] - 2026-01-15
 
 ### Theme: Release Automation
 

--- a/scripts/lib/validate.sh
+++ b/scripts/lib/validate.sh
@@ -47,10 +47,14 @@ validate_run_scenario() {
     local scenario="$1"
     local host="$2"
     local verbose="${3:-false}"
+    local packer_release="${4:-}"
 
     local cmd="${IAC_DRIVER_DIR}/run.sh --scenario ${scenario} --host ${host}"
     if [[ "$verbose" == "true" ]]; then
         cmd+=" --verbose"
+    fi
+    if [[ -n "$packer_release" ]]; then
+        cmd+=" --packer-release ${packer_release}"
     fi
 
     log_info "Running: $cmd"
@@ -71,14 +75,20 @@ validate_run_remote() {
     local scenario="$2"
     local host="$3"
     local verbose="${4:-false}"
+    local packer_release="${5:-}"
 
     local verbose_flag=""
     if [[ "$verbose" == "true" ]]; then
         verbose_flag="--verbose"
     fi
 
+    local packer_release_flag=""
+    if [[ -n "$packer_release" ]]; then
+        packer_release_flag="--packer-release ${packer_release}"
+    fi
+
     # Build the remote command
-    local remote_cmd="cd ~/homestak-dev && ./scripts/release.sh validate --scenario ${scenario} --host ${host} ${verbose_flag}"
+    local remote_cmd="cd ~/homestak-dev && ./scripts/release.sh validate --scenario ${scenario} --host ${host} ${verbose_flag} ${packer_release_flag}"
 
     log_info "Running validation on ${remote_host}..."
     log_info "Remote command: ${remote_cmd}"
@@ -110,6 +120,7 @@ run_validation() {
     local skip="${3:-false}"
     local verbose="${4:-false}"
     local remote_host="${5:-}"
+    local packer_release="${6:-}"
 
     # Handle skip
     if [[ "$skip" == "true" ]]; then
@@ -149,11 +160,11 @@ run_validation() {
     # Run the scenario (remote or local)
     local scenario_passed=false
     if [[ -n "$remote_host" ]]; then
-        if validate_run_remote "$remote_host" "$scenario" "$host" "$verbose"; then
+        if validate_run_remote "$remote_host" "$scenario" "$host" "$verbose" "$packer_release"; then
             scenario_passed=true
         fi
     else
-        if validate_run_scenario "$scenario" "$host" "$verbose"; then
+        if validate_run_scenario "$scenario" "$host" "$verbose" "$packer_release"; then
             scenario_passed=true
         fi
     fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -324,6 +324,7 @@ cmd_validate() {
     local skip=false
     local verbose=false
     local remote=""
+    local packer_release=""
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -337,6 +338,10 @@ cmd_validate() {
                 ;;
             --remote)
                 remote="$2"
+                shift 2
+                ;;
+            --packer-release)
+                packer_release="$2"
                 shift 2
                 ;;
             --skip)
@@ -361,7 +366,7 @@ cmd_validate() {
 
     # Run validation
     local validation_passed=false
-    if run_validation "$scenario" "$host" "$skip" "$verbose" "$remote"; then
+    if run_validation "$scenario" "$host" "$skip" "$verbose" "$remote" "$packer_release"; then
         validation_passed=true
     fi
 
@@ -1199,6 +1204,7 @@ Options:
   --reset-repo REPO  Reset tag for single repo only
   --skip             Skip validation (emergency releases only)
   --remote HOST      Run validation on remote host via SSH
+  --packer-release   Packer release tag for image downloads (validate only)
   --host HOST        Check host readiness (preflight only, repeatable)
   --workflow         Use GitHub Actions workflow for packer copy (vs local)
   --no-wait          Don't wait for workflow completion (packer only)
@@ -1214,6 +1220,7 @@ Examples:
   release.sh preflight --host father --host mother
   release.sh validate --scenario vm-roundtrip --host father
   release.sh validate --scenario vm-roundtrip --host father --remote father
+  release.sh validate --scenario nested-pve-roundtrip --host father --packer-release v0.19
   release.sh validate --skip
   release.sh tag --dry-run
   release.sh tag --execute


### PR DESCRIPTION
## Summary
- Add `--packer-release` flag to `release.sh validate` command
- Pass through to iac-driver's `--packer-release` option

## Motivation
During v0.20 release, `nested-pve-roundtrip` validation failed because the `latest` packer tag pointed to a draft release. There was no way to specify `--packer-release v0.19` through release.sh - users had to run iac-driver directly.

## Changes
- Add `--packer-release` option parsing to `cmd_validate()` in release.sh
- Pass parameter through `run_validation()` to `validate_run_scenario()`
- Pass parameter through to `validate_run_remote()` for SSH execution
- Update help text with new option and example

## Usage
```bash
release.sh validate --scenario nested-pve-roundtrip --host father --packer-release v0.19
```

## Test plan
- [x] Bash syntax check passes
- [x] `release.sh help` shows new option
- [ ] Manual test: run validate with --packer-release flag

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)