### PR TITLE
feat: Improve release issue tracking visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ All notable changes to this project will be documented in this file.
   - Passes through to iac-driver's `--packer-release` option
   - Enables validation with specific packer release when `latest` tag points to draft
 
+### Improved
+- Release issue tracking visibility throughout release process (#77)
+  - `release.sh init` shows tip to link release issue if not provided
+  - `release.sh status` shows yellow warning when no issue is linked
+  - Add release issue checkpoint to lifecycle docs (Phase 1: Pre-flight)
+  - Add directive to CLAUDE.md about identifying release issue at session start
+
 ---
 
 ## [v0.20] - 2026-01-15

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,10 @@ The `scripts/release.sh` CLI automates multi-repo release operations.
 ./scripts/release.sh full --execute --host father
 ```
 
+### Release Issue Tracking
+
+**Important:** When executing a release, always identify the release tracking issue at session start. Use `gh issue list --label release` or check for open issues titled "vX.Y Release Planning". Include `--issue N` when running `release.sh init` to link the release state to the tracking issue.
+
 ### State Files
 
 | File | Purpose |

--- a/docs/lifecycle/60-release.md
+++ b/docs/lifecycle/60-release.md
@@ -57,6 +57,9 @@ Before starting release work:
 
 ### Phase 1: Pre-flight
 
+- [ ] **Identify release tracking issue** (e.g., homestak-dev#XX)
+  - Look for open issues titled "vX.Y Release Planning" or labeled `release`
+  - Include `--issue XX` when running `release.sh init`
 - [ ] Git fetch on all repos (avoid rebase surprises)
 - [ ] All PRs merged to main branches
 - [ ] Working trees clean (`git status` on all repos)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -154,6 +154,9 @@ cmd_init() {
     echo "  Release v${version} initialized"
     if [[ -n "$issue" ]]; then
         echo "  Tracking issue: #${issue}"
+    else
+        echo -e "  ${YELLOW}Tip: Link a release issue with --issue N${NC}"
+        echo "  Look for: gh issue list --label release"
     fi
     echo "═══════════════════════════════════════════════════════════════"
     echo ""
@@ -191,6 +194,8 @@ cmd_status() {
     echo "  Release v${version} - Status: ${status}"
     if [[ -n "$issue" ]]; then
         echo "  Tracking: https://github.com/homestak-dev/homestak-dev/issues/${issue}"
+    else
+        echo -e "  Tracking: ${YELLOW}(no issue linked)${NC}"
     fi
     echo "═══════════════════════════════════════════════════════════════"
     echo ""


### PR DESCRIPTION
## Summary
Add prompts and warnings to keep release tracking issue visible throughout the release process.

## Motivation
During v0.20 release, the release tracking issue (homestak-dev#72) was forgotten until the AAR phase. When AI sessions are continued from summarized context, "ambient" details like issue numbers can be lost.

## Changes
- **release.sh init**: Show tip to link release issue when `--issue` not provided
- **release.sh status**: Show yellow warning when no issue is linked
- **docs/lifecycle/60-release.md**: Add release issue checkpoint to Phase 1 Pre-flight
- **CLAUDE.md**: Add directive about identifying release issue at session start

## Test plan
- [x] Bash syntax check passes
- [ ] Manual test: `release.sh init --version 0.99-test` shows tip
- [ ] Manual test: `release.sh status` shows "(no issue linked)" warning

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)