### PR TITLE
feat: Use per-image .sha256 checksums in packer copy (packer#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased] - v0.21
+## [Unreleased] - v0.22
+
+### Changed
+- `release.sh packer --copy` now uses per-image `.sha256` checksums (packer#29)
+  - Downloads `.qcow2` images and accompanying `.sha256` files from source release
+  - Excludes legacy `SHA256SUMS` (consolidated format, deprecated)
+  - Aligns with packer build.sh which generates per-image checksums
+
+---
+
+## [v0.21] - 2026-01-15
 
 ### Added
 - `release.sh validate --packer-release` flag for specifying packer image version (#74)


### PR DESCRIPTION
## Summary

- Updates `release.sh packer --copy` to use per-image `.sha256` checksums
- Deprecates consolidated `SHA256SUMS` format in favor of Debian cloud image convention
- Aligns release tooling with packer build.sh changes from PR#35

## Changes

- Download `.qcow2` images AND `.sha256` files from source release
- Exclude legacy `SHA256SUMS` (consolidated format, deprecated)
- Remove `SHA256SUMS` generation during copy operation
- Updated success message to show image and checksum counts

## Test plan

- [x] `release.sh packer --copy --dry-run` shows correct commands
- [ ] Integration with packer PR#35 when images have .sha256 files

Closes packer#29

🤖 Generated with [Claude Code](https://claude.com/claude-code)