### PR TITLE
fix: Correct gh workflow list syntax in release.sh (.github#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ All notable changes to this project will be documented in this file.
   - Excludes legacy `SHA256SUMS` (consolidated format, deprecated)
   - Aligns with packer build.sh which generates per-image checksums
 
+### Fixed
+- Fix `release.sh packer --workflow` gh CLI syntax (.github#30)
+  - Changed workflow existence check to use correct `gh workflow list` output format
+  - Removed unsupported `--json` flag from workflow list command
+
+### Cross-Repo Changes
+
+**packer v0.22:**
+- Fix copy-images workflow to support `latest` as target (.github#30)
+  - Relaxed validation to accept `latest` OR `vX.Y` format
+  - Auto-create `latest` release if it doesn't exist
+  - Fix `force` parameter type in tag update API call (use `-F` for boolean)
+  - Improved error messages and debugging output
+
 ---
 
 ## [v0.21] - 2026-01-15

--- a/scripts/lib/publish.sh
+++ b/scripts/lib/publish.sh
@@ -94,8 +94,8 @@ packer_dispatch_copy_images() {
         return 0
     fi
 
-    # Check if workflow exists
-    if ! gh workflow list --repo homestak-dev/packer --json name -q '.[].name' 2>/dev/null | grep -q "Copy Images"; then
+    # Check if workflow exists (gh workflow list outputs: NAME STATUS ID)
+    if ! gh workflow list --repo homestak-dev/packer 2>/dev/null | grep -q "^Copy Images"; then
         log_warn "Workflow '$workflow' not found in packer repo"
         log_info "Images must be copied manually or workflow created"
         return 1


### PR DESCRIPTION
## Summary

Fixes the `release.sh packer --workflow` command which was failing due to incorrect gh CLI syntax.

## Problem

The code was using:
```bash
gh workflow list --repo ... --json name -q '.[].name'
```

But `gh workflow list` doesn't support the `--json` flag.

## Solution

Changed to use the plain text output format:
```bash
gh workflow list --repo ... | grep -q "^Copy Images"
```

## Test plan

- [ ] `release.sh packer --workflow --dry-run` shows correct workflow dispatch command
- [ ] Integration with packer PR#37 (copy-images workflow fix)

## Related

Partial fix for .github#30 (companion to packer PR#37)

🤖 Generated with [Claude Code](https://claude.com/claude-code)