### PR TITLE
docs: Adopt latest-centric packer image distribution (#83)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ All notable changes to this project will be documented in this file.
   - Changed workflow existence check to use correct `gh workflow list` output format
   - Removed unsupported `--json` flag from workflow list command
 
+### Documentation
+- Adopt latest-centric packer image distribution (#83)
+  - `latest` is now the primary image source; versioned releases typically have no images
+  - Updated `docs/lifecycle/60-release.md` Phase 5 with Option A (skip) / Option B (rebuild) paths
+  - Updated verification expectations and release checklists
+  - Added `packer_release: latest` note to site-config/CLAUDE.md
+
 ### Cross-Repo Changes
 
 **packer v0.22:**


### PR DESCRIPTION
## Summary

Updates release documentation to reflect the latest-centric packer image distribution approach.

## Key Changes

### Phase 5: Packer Images

- **Option A (default):** Most releases skip image handling entirely - automation uses `latest`
- **Option B (when needed):** Rebuild images and update `latest` only when templates change

### When to rebuild:
- Packer template changes (new packages, cloud-init fixes)
- Base Debian image updates (12.x → 12.y point release)
- Security fixes in image content
- New image variants added

### When to skip:
- Documentation-only changes
- Build script refactoring (unless it affects output)
- CHANGELOG updates
- Releases where templates haven't changed

## Files Changed

- `docs/lifecycle/60-release.md` - Phase 5 rewritten, verification updated
- `CHANGELOG.md` - Added to v0.22 Unreleased

## Related

- site-config PR#35 (companion docs update)
- .github#30 (enables `latest` as GHA workflow target)

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)