### PR TITLE
docs: Establish squash vs merge convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+- Document merge strategy convention (#127)
+  - Add "Merge Strategy" section to `docs/lifecycle/50-merge.md`
+  - Add merge method settings to `docs/REPO-SETTINGS.md`
+  - Default: squash merge; merge commits for well-structured PRs
+
 ## v0.33 - 2026-01-19
 
 ### Theme: Unit Testing

--- a/docs/REPO-SETTINGS.md
+++ b/docs/REPO-SETTINGS.md
@@ -159,11 +159,20 @@ gh api repos/homestak-dev/NEW_REPO/vulnerability-alerts -X PUT
 
 | Setting | Value | Notes |
 |---------|-------|-------|
+| Allow squash merging | Enabled | Default merge method |
+| Allow merge commits | Enabled | For well-structured PRs |
+| Allow rebase merging | Disabled | Avoid history complications |
+| Default merge method | Squash | Matches [50-merge.md](lifecycle/50-merge.md) guidance |
 | Auto-delete head branches | Enabled | Prevents stale branch accumulation (v0.21+) |
 
-**CLI to enable:**
+**CLI to configure merge methods:**
 ```bash
-gh api -X PATCH repos/homestak-dev/REPO_NAME -f delete_branch_on_merge=true
+gh api -X PATCH repos/homestak-dev/REPO_NAME \
+  -f allow_squash_merge=true \
+  -f allow_merge_commit=true \
+  -f allow_rebase_merge=false \
+  -f squash_merge_commit_title=PR_TITLE \
+  -f delete_branch_on_merge=true
 ```
 
 ## Current Repository Settings

--- a/docs/lifecycle/50-merge.md
+++ b/docs/lifecycle/50-merge.md
@@ -93,7 +93,19 @@ PR requires human action:
 - Review test coverage
 - Review documentation updates
 - Approve PR
-- Merge PR (squash or merge per repo convention)
+- Merge PR (see Merge Strategy below)
+
+### Merge Strategy
+
+| PR Type | Strategy | Rationale |
+|---------|----------|-----------|
+| Most PRs | **Squash** | Clean history, one logical change per merge |
+| Well-structured multi-commit PRs | **Merge commit** | Preserves meaningful commit breakdown |
+| Rebase | **Avoid** | Complicates history for reviewers |
+
+**Default: Squash merge.** Use merge commits only when the PR has intentionally structured commits that tell a story (e.g., "refactor X", then "add Y", then "update tests").
+
+**Single-commit PRs:** Either method produces the same result; squash is fine.
 
 ### 6. Post-Merge Verification
 


### PR DESCRIPTION
## Summary

Establishes a documented convention for merge strategies (squash vs merge vs rebase) across homestak-dev repositories.

## Type of Change
- [x] Documentation

## Changes

**docs/lifecycle/50-merge.md:**
- Add "Merge Strategy" section with decision table
- Default: squash merge for clean history
- Exception: merge commits for well-structured multi-commit PRs
- Avoid: rebase merging (complicates history)

**docs/REPO-SETTINGS.md:**
- Add GitHub repo merge method settings
- CLI command to configure all merge settings at once

## Testing

Documentation-only change. No integration testing required.

## Related Issues

Closes #127

## Checklist
- [x] CHANGELOG.md updated
- [x] Documentation accurate

🤖 Generated with [Claude Code](https://claude.ai/code)