### PR TITLE
Add secrets auto-decrypt in preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changed
+- Preflight now auto-decrypts secrets.yaml when secrets.yaml.enc exists (#140)
+
 ### Documentation
 - Add explicit post-merge sync step to 50-merge.md (lesson from v0.35, v0.37)
 - Add explicit release.sh init step to 60-release.md Phase 1 (lesson from v0.37)


### PR DESCRIPTION
## Summary
- Preflight now automatically decrypts secrets.yaml when secrets.yaml.enc exists
- New status values: `auto_decrypted`, `decrypt_failed`
- Eliminates manual `make decrypt` step before running preflight

## Test plan
- [x] `make test` passes (43/43 tests)
- [x] shellcheck passes

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)