### PR TITLE
docs(design): Add v0.45 specify server design

### DIFF
--- a/docs/designs/v0.45-specify-server.md
+++ b/docs/designs/v0.45-specify-server.md
@@ -1,0 +1,211 @@
+# Design Summary: `homestak serve`
+
+**Sprint:** #161 (v0.45 Specify Server Foundation)
+**Release:** #153
+**Epic:** iac-driver#125 (Architecture evolution)
+**Author:** Claude
+**Date:** 2026-02-01
+
+## Problem Statement
+
+Nodes need to discover their specifications autonomously rather than being passively configured. The `homestak serve` command provides an HTTP server that exposes specs from `site-config/v2/specs/` to requesting nodes.
+
+**Success criteria:**
+- Server starts and binds to port 44443
+- GET `/spec/{identity}` returns resolved spec JSON
+- Auth tokens validated per posture (network/site_token/node_token)
+- Error responses use defined error codes
+
+## Proposed Solution
+
+**Summary:** Python HTTP server in bootstrap that serves resolved specs with posture-based authentication.
+
+**High-level approach:**
+- Lightweight HTTP server using Python's `http.server` (stdlib, no deps)
+- Spec resolution: load YAML, resolve FKs (posture, ssh_keys)
+- Auth validation before serving spec
+- JSON response with resolved spec
+- Memory cache with SIGHUP handler to clear
+
+**Key components affected:**
+- `bootstrap/lib/serve.py` - New Python module for HTTP server
+- `bootstrap/homestak.sh` - Add `serve` subcommand routing
+
+**New components introduced:**
+- `bootstrap/lib/serve.py` - HTTP server implementation
+- `bootstrap/lib/spec_resolver.py` - Spec loading and FK resolution
+
+## Interface Design
+
+### HTTP API
+
+| Method | Endpoint | Auth | Response |
+|--------|----------|------|----------|
+| GET | `/spec/{identity}` | Per posture | Resolved spec JSON |
+| GET | `/health` | None | `{"status": "ok"}` |
+
+### Request Headers
+
+```
+Authorization: Bearer <token>   # For site_token/node_token auth
+X-Homestak-Identity: <name>     # Optional, can also be in URL path
+```
+
+### Response Format (Success)
+
+```json
+{
+  "schema_version": 1,
+  "identity": {"hostname": "dev1", "domain": "homestak.local"},
+  "access": {"posture": "dev", "users": [...]},
+  "platform": {"packages": [...], "services": {...}}
+}
+```
+
+### Response Format (Error)
+
+```json
+{
+  "error": {
+    "code": "E201",
+    "message": "Spec not found: dev1"
+  }
+}
+```
+
+### Error Codes
+
+| Code | HTTP Status | Meaning |
+|------|-------------|---------|
+| E100 | 400 | Bad request (malformed) |
+| E101 | 400 | Missing identity |
+| E200 | 404 | Spec not found |
+| E201 | 404 | Posture not found |
+| E202 | 404 | SSH key not found |
+| E300 | 401 | Auth required |
+| E301 | 403 | Invalid token |
+| E302 | 403 | Token expired |
+| E400 | 422 | Schema validation failed |
+| E500 | 500 | Internal server error |
+| E501 | 503 | Service unavailable |
+
+### CLI
+
+```bash
+homestak serve [--port 44443] [--bind 0.0.0.0] [--verbose]
+```
+
+### Configuration
+
+- Specs read from: `$HOMESTAK_ETC/v2/specs/`
+- Postures read from: `$HOMESTAK_ETC/v2/postures/`
+- Secrets read from: `$HOMESTAK_ETC/secrets.yaml`
+
+## Auth Flow
+
+```
+Request arrives
+    │
+    ▼
+Load spec for {identity}
+    │
+    ▼
+Get posture from spec.access.posture (default: "dev")
+    │
+    ▼
+Load posture → get auth.method
+    │
+    ├── network → Trust (no token required)
+    │
+    ├── site_token → Check Authorization header
+    │   │            against secrets.auth.site_token
+    │   │
+    │   └── Match? → Serve spec
+    │       No match → E301
+    │
+    └── node_token → Check Authorization header
+        │            against secrets.auth.node_tokens.{identity}
+        │
+        └── Match? → Serve spec
+            No match → E301
+```
+
+### Auth Scope (v0.45)
+
+| Auth Method | v0.45 | Deferred |
+|-------------|-------|----------|
+| network | Implement | - |
+| site_token | Implement | - |
+| node_token | - | v0.47 |
+
+## Caching Strategy
+
+- Memory cache for resolved specs
+- SIGHUP handler clears cache (no restart required for config changes)
+- Log message on cache clear: `"Cache cleared (SIGHUP received)"`
+- Validate specs against schema on request (not startup), cache result
+
+## Integration Points
+
+1. **site-config v2 structure** - Reads specs, postures, secrets
+2. **bootstrap path resolution** - Uses existing `HOMESTAK_ETC` discovery
+3. **Future: cloud-init (v0.47)** - Will inject `HOMESTAK_DISCOVERY` URL
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Secrets exposure if auth bypassed | Low | High | Auth check before any spec access |
+| Port conflict with existing service | Low | Low | Configurable port, default 44443 |
+| Large specs cause timeout | Low | Low | Specs are small YAML, not a concern |
+| Missing secrets.yaml | Medium | Medium | Graceful error E500 with clear message |
+
+## Alternatives Considered
+
+| Alternative | Pros | Cons | Why Not |
+|-------------|------|------|---------|
+| Flask/FastAPI | Full-featured, async | External dependency | stdlib preferred for bootstrap |
+| Shell + nc | No Python | Complex, fragile | Python already available |
+| Static file server | Simpler | No auth, no FK resolution | Auth required by design |
+
+## Test Plan
+
+**Automated test script:** `bootstrap/test/test_serve.sh`
+
+**Test cases:**
+1. Health check returns 200 + `{"status": "ok"}`
+2. GET `/spec/base` returns resolved spec (network auth)
+3. GET `/spec/pve` with valid site_token returns spec
+4. GET `/spec/pve` without token returns E300 (if posture requires)
+5. GET `/spec/nonexistent` returns E200
+6. Invalid token returns E301
+7. Malformed request returns E100
+
+**Expected results:**
+- Health returns `{"status": "ok"}`
+- Spec returns resolved JSON with FK values expanded
+- Errors return proper codes and messages
+
+## Prerequisites
+
+| Category | Check | Status |
+|----------|-------|--------|
+| v2 structure | `site-config/v2/specs/` exists | Ready |
+| Postures | `site-config/v2/postures/` exists | Ready |
+| Schemas | `site-config/v2/defs/*.json` exist | Ready |
+| Secrets | `secrets.yaml` with auth.site_token | Needs addition |
+
+## Open Questions (Resolved)
+
+1. **Should serve validate specs against schema on startup?**
+   - Decision: Validate on request, cache result
+
+2. **Should serve watch for file changes?**
+   - Decision: No, but SIGHUP handler clears cache
+
+## Related Documents
+
+- [iac-driver#125](https://github.com/homestak-dev/iac-driver/issues/125) - Architecture evolution epic
+- [homestak-dev#153](https://github.com/homestak-dev/homestak-dev/issues/153) - v0.45 Release Planning
+- [site-config/v2/defs/spec.schema.json](../site-config/v2/defs/spec.schema.json) - Spec schema
+- [site-config/v2/defs/posture.schema.json](../site-config/v2/defs/posture.schema.json) - Posture schema


### PR DESCRIPTION
## Summary

- Add design document for `homestak serve` (v0.45 Specify phase)

## Changes

- `docs/designs/v0.45-specify-server.md` - Full design covering HTTP API, auth flow, error codes

## Related

- Sprint: #161
- Release: #153
- Epic: iac-driver#125

---
🤖 Generated with [Claude Code](https://claude.ai/code)