### PR TITLE
Sprint 171: v0.45 Foundation (Docs)

### DIFF
--- a/docs/designs/v0.44-specify-client.md
+++ b/docs/designs/v0.44-specify-client.md
@@ -13,7 +13,7 @@ Nodes need to fetch their specifications from the spec server (`homestak serve`)
 **Success criteria:**
 - Client fetches spec from server via HTTP
 - CLI flags work for manual testing: `--server`, `--identity`, `--token`
-- Env vars work for automated path: `HOMESTAK_DISCOVERY`, `HOMESTAK_IDENTITY`, `HOMESTAK_AUTH_TOKEN`
+- Env vars work for automated path: `HOMESTAK_SPEC_SERVER`, `HOMESTAK_IDENTITY`, `HOMESTAK_AUTH_TOKEN`
 - Fetched spec persisted to `/usr/local/etc/homestak/state/`
 - Error responses handled with defined codes
 
@@ -47,7 +47,7 @@ Nodes need to fetch their specifications from the spec server (`homestak serve`)
 homestak spec get --server https://father:44443 --identity dev1 [--token mytoken]
 
 # Automated invocation (via env vars, for cloud-init path)
-HOMESTAK_DISCOVERY=https://father:44443 \
+HOMESTAK_SPEC_SERVER=https://father:44443 \
 HOMESTAK_IDENTITY=dev1 \
 HOMESTAK_AUTH_TOKEN=mytoken \
 homestak spec get
@@ -64,7 +64,7 @@ homestak spec get
 
 | Variable | Description | Required |
 |----------|-------------|----------|
-| `HOMESTAK_DISCOVERY` | Server URL (e.g., `https://father:44443`) | Yes (if no --server) |
+| `HOMESTAK_SPEC_SERVER` | Server URL (e.g., `https://father:44443`) | Yes (if no --server) |
 | `HOMESTAK_IDENTITY` | Node identity (e.g., `dev1`) | Yes (if no --identity) |
 | `HOMESTAK_AUTH_TOKEN` | Bearer token for auth | If posture requires |
 
@@ -133,7 +133,7 @@ homestak spec get
        ▼
 Parse CLI flags / env vars
        │
-       ├── --server / HOMESTAK_DISCOVERY
+       ├── --server / HOMESTAK_SPEC_SERVER
        ├── --identity / HOMESTAK_IDENTITY
        └── --token / HOMESTAK_AUTH_TOKEN
        │

--- a/docs/designs/v0.44-specify-server.md
+++ b/docs/designs/v0.44-specify-server.md
@@ -149,7 +149,7 @@ Load posture → get auth.method
 
 1. **site-config v2 structure** - Reads specs, postures, secrets
 2. **bootstrap path resolution** - Uses existing `HOMESTAK_ETC` discovery
-3. **Future: cloud-init (v0.47)** - Will inject `HOMESTAK_DISCOVERY` URL
+3. **Future: cloud-init (v0.45)** - Will inject `HOMESTAK_SPEC_SERVER` URL
 
 ## Risk Assessment
 


### PR DESCRIPTION
## Summary

Rename HOMESTAK_DISCOVERY → HOMESTAK_SPEC_SERVER in design documents to align terminology before implementation.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation
- [x] Sprint merge

## Changes
- Update v0.44-specify-server.md: cloud-init reference uses new env var name
- Update v0.44-specify-client.md: all env var references renamed
- vm-lifecycle-architecture.md: no changes needed (no references found)

## Testing
- Unit tests: N/A (documentation only)
- Integration scenario: grep verification
- Validation result: PASSED

```
HOMESTAK_DISCOVERY references: 0 (correct - all renamed)
HOMESTAK_SPEC_SERVER references: 5 (correct - new name in use)
```

## Sprint Scope
- From #154 Sprint 1 scope

## Validation Evidence
- Scenario: Manual validation (docs-only changes)
- Result: PASSED
- Validation: grep confirms all references updated

## Related Issues
Part of: #171
Refs: #154 (v0.45 Release)

## Checklist
- [x] Tests pass locally (grep validation)
- [x] Integration scenario passes
- [x] Documentation updated (this is the docs update)