### PR TITLE
docs: Update design docs to verb-based CLI and operator terminology

### DIFF
--- a/docs/designs/gap-analysis.md
+++ b/docs/designs/gap-analysis.md
@@ -24,7 +24,7 @@ This document tracks the design documentation landscape for the homestak lifecyc
 |----------|--------|----------|-------------|
 | `config-apply.md` | iac-driver (TBD) | P0 | Config phase implementation to reach "platform ready" state |
 | `manifest-schema-v2.md` | iac-driver#140-P2 | P0 | Manifest schema v2 with `nodes` graph structure, absorbs `node.schema.json` |
-| `scenario-consolidation.md` | iac-driver#140-P4 | P1 | Transitional doc for migrating from `*-constructor/*-destructor` to `--manifest X --action Y` |
+| `scenario-consolidation.md` | iac-driver#145 | P1 | Transitional doc for migrating from `*-constructor/*-destructor` to verb-based subcommands |
 
 ### Document Dependencies
 
@@ -39,7 +39,7 @@ node-orchestration.md (complete)
         │
         ├── manifest-schema-v2.md (missing) ──► iac-driver#140-P2
         │
-        └── scenario-consolidation.md (missing, transitional) ──► iac-driver#140-P4
+        └── scenario-consolidation.md (missing, transitional) ──► iac-driver#145
                                                                         │
                                                                         └── Archive after migration
 ```
@@ -52,8 +52,8 @@ Identified issues in existing design documents that should be corrected.
 
 | Section | Issue | Fix |
 |---------|-------|-----|
-| CLI examples | Uses `homestak ...` command pattern | Update to `./run.sh --manifest X --action Y` |
-| Architecture Alignment | References "manifest-executor.md" | Remove reference - manifest execution is inline in `cli.py` |
+| CLI examples | ~~Uses `homestak ...` command pattern~~ | **Complete** — Updated to verb-based `./run.sh create/destroy/test -M X -H host` |
+| Architecture Alignment | ~~References "manifest-executor.md"~~ | **Complete** — Operator package replaces inline execution (#144) |
 | Implementation Relationship | References phase numbers from sprint planning | Update to reference design docs directly |
 
 ### node-lifecycle.md
@@ -78,12 +78,12 @@ Items identified during Sprint 0 analysis for NFR (Non-Functional Requirements) 
 
 | Current | Issue | Target |
 |---------|-------|--------|
-| `vm-constructor` | Action encoded in name | Retire after `--action create` |
-| `vm-destructor` | Action encoded in name | Retire after `--action destroy` |
-| `vm-roundtrip` | Test pattern encoded in name | Retire after `--action test` |
-| `nested-pve-constructor` | Hardcoded 2-level | Retire after manifest support |
-| `nested-pve-destructor` | Hardcoded 2-level | Retire after manifest support |
-| `nested-pve-roundtrip` | Hardcoded 2-level | Retire after manifest support |
+| `vm-constructor` | Action encoded in name | Retire after `./run.sh create` |
+| `vm-destructor` | Action encoded in name | Retire after `./run.sh destroy` |
+| `vm-roundtrip` | Test pattern encoded in name | Retire after `./run.sh test` |
+| `nested-pve-constructor` | Hardcoded 2-level | Retire after manifest operator (#144) |
+| `nested-pve-destructor` | Hardcoded 2-level | Retire after manifest operator (#144) |
+| `nested-pve-roundtrip` | Hardcoded 2-level | Retire after manifest operator (#144) |
 | `recursive-pve-*` | Old manifest format | Retire after v2 manifest support |
 
 ### Directory Structure (iac-driver)
@@ -105,7 +105,7 @@ Items identified during Sprint 0 analysis for NFR (Non-Functional Requirements) 
 | Location | Item | Disposition |
 |----------|------|-------------|
 | `iac-driver/src/scenarios/cleanup_nested_pve.py` | Shared cleanup actions | Evaluate after scenario consolidation |
-| `iac-driver/src/actions/recursive.py` | RecursiveScenarioAction | May become manifest-executor primitive |
+| `iac-driver/src/actions/recursive.py` | RecursiveScenarioAction | May become operator primitive |
 
 ## Gap Closure Tracking
 
@@ -113,19 +113,25 @@ Track progress on closing design gaps.
 
 | Gap | Target Sprint | Status | Notes |
 |-----|--------------|--------|-------|
-| config-apply.md | Sprint 4 (iac-driver TBD) | Not started | Blocks first "platform ready" |
-| manifest-schema-v2.md | Sprint 2 (#140-P2) | Not started | Blocks CLI simplification |
-| scenario-consolidation.md | Sprint 5 (#140-P4) | Not started | Transitional, archive after |
+| unified-controller (#148) | Sprint 1 (#146) | **Complete** | Delivered in PR #150, #148 closed |
+| config-apply.md | Sprint 4 (iac-driver#147) | Not started | Blocks first "platform ready" |
+| manifest-schema-v2.md | Sprint 2 (#143) | Not started | Blocks operator (#144) |
+| scenario-consolidation.md | Sprint 5 (#145) | Not started | Transitional, archive after |
 | phase-interfaces.md | Sprint 0 | **Complete** | Resolved Q1-Q6, documented all phase contracts |
-| node-orchestration.md CLI examples | Sprint 0 | **Complete** | Updated to `./run.sh --manifest X --action Y` |
+| node-orchestration.md CLI examples | Sprint 0 | **Complete** | Updated to verb-based `./run.sh create/destroy/test` |
 | node-lifecycle.md phase-interfaces ref | Sprint 0 | **Complete** | Added cross-reference |
+| CLI verb pattern update | Sprint 0 | **Complete** | All design docs updated from `--manifest X --action Y` to verb subcommands |
 | requirements-catalog.md Source column | Sprint 0 | **Complete** | Added Source tracking, 11 implicit requirements |
+| requirements-catalog.md CTL category | Sprint 1 | **Complete** | Added controller requirements (REQ-CTL-001 to 010) |
 | Terminology standardization | Sprint 0 | **Complete** | "spec server" not "config server" |
 
 ## Changelog
 
 | Date | Change |
 |------|--------|
+| 2026-02-05 | Updated CLI pattern references to verb-based subcommands; marked #148 complete; updated scenario retirement targets |
+| 2026-02-05 | Added unified controller (#148) to gap tracking; added CTL category to requirements |
+| 2026-02-04 | Updated Sprint 4 to reference iac-driver#147 (config phase) |
 | 2026-02-04 | Removed homestak-dev#155 references (closed - config phase belongs in iac-driver) |
 | 2026-02-04 | Updated Gap Closure Tracking with Sprint 0 completions |
 | 2026-02-03 | Initial document |

--- a/docs/designs/node-lifecycle.md
+++ b/docs/designs/node-lifecycle.md
@@ -132,7 +132,7 @@ Nodes discover their spec and converge autonomously.
 ```
 Driver                           Target
 ──────                           ──────
-1. homestak serve (spec server)
+1. ./run.sh serve (controller daemon)
 2. tofu apply (inject identity + endpoint)
                                  3. Boot with identity
                                  4. homestak spec get
@@ -140,7 +140,7 @@ Driver                           Target
    GET /spec/{identity}          │
    ─────────────────────────────▶
    200 OK + spec                 │
-                                 5. homestak config
+                                 5. Apply spec locally (future)
                                  6. PLATFORM READY
 ```
 
@@ -345,21 +345,21 @@ parent: father               # Parent node (for VMs)
 
 ## CLI Pattern
 
+**Driver CLI** (`./run.sh` — iac-driver, verb-based subcommands):
+
 ```bash
-homestak <noun> <verb> [args...]
+./run.sh serve                              # Start controller daemon
+./run.sh create -M <manifest> -H <host>     # Create nodes per manifest
+./run.sh destroy -M <manifest> -H <host>    # Destroy nodes per manifest
+./run.sh test -M <manifest> -H <host>       # Roundtrip validation
+./run.sh config -M <manifest> -H <host>     # Config phase (future)
+```
 
-# Spec management
+**Target CLI** (`homestak` — bootstrap, runs on target nodes):
+
+```bash
 homestak spec validate <path>     # Validate spec against schema
-homestak spec get                 # Fetch spec from server
-
-# Server
-homestak serve                    # Start spec server
-
-# Future
-homestak config                   # Apply spec to reach platform ready
-homestak node create <template>   # Create node from template
-homestak node list                # List nodes
-homestak node destroy <name>      # Destroy node
+homestak spec get                 # Fetch spec from server (pull model)
 ```
 
 ## Scope & Relationship
@@ -421,7 +421,7 @@ The architecture is being implemented incrementally across multiple releases.
 | Release | Phase | Deliverables |
 |---------|-------|--------------|
 | v0.43 | Schema Foundation | V2 directory structure, JSON schemas for specs/nodes/postures |
-| v0.44 | Config Infrastructure | `homestak serve` server, `homestak spec get` client, auth model |
+| v0.44 | Config Infrastructure | Spec server, `homestak spec get` client, auth model |
 | v0.45 | create → config | Cloud-init integration, auth token injection, `spec-vm-roundtrip` scenario |
 
 ### v0.45 Details (create → config)
@@ -451,6 +451,7 @@ The architecture is being implemented incrementally across multiple releases.
 
 | Date | Change |
 |------|--------|
+| 2026-02-05 | Update CLI Pattern section: distinguish driver CLI (`./run.sh`) from target CLI (`homestak`); remove premature `homestak config` porcelain reference |
 | 2026-02-03 | Rename to node-lifecycle.md; normalize execution models as co-equal (push/hybrid/pull all first-class); add terminology framework; remove "In Progress" section |
 | 2026-02-03 | Rename to node-lifecycle-architecture.md; consolidate to 4 phases (create, config, run, destroy); add #140 epic, scope & relationship section |
 | 2026-02-02 | Update for v0.45: create → config integration complete |

--- a/docs/designs/phase-interfaces.md
+++ b/docs/designs/phase-interfaces.md
@@ -244,16 +244,16 @@ Each manifest-node combination has isolated state:
 **Implementation:**
 ```bash
 # Default: stop on failure
-./run.sh --manifest nested-test --action create --host father
+./run.sh create -M nested-test -H father
 
 # Explicit stop (same as default)
-./run.sh --manifest nested-test --action create --host father --on-error=stop
+./run.sh create -M nested-test -H father --on-error=stop
 
 # Rollback on failure
-./run.sh --manifest nested-test --action create --host father --on-error=rollback
+./run.sh create -M nested-test -H father --on-error=rollback
 
 # Continue despite failures
-./run.sh --manifest nested-test --action create --host father --on-error=continue
+./run.sh create -M nested-test -H father --on-error=continue
 ```
 
 ### Q3: Run Phase Triggers


### PR DESCRIPTION
## Summary
- Replace old `--manifest X --action Y` CLI pattern with verb subcommands (`./run.sh create/destroy/test -M <manifest> -H <host>`)
- Replace "manifest executor" terminology with "operator" (iac-driver#144)
- Replace premature `homestak config` references with "config phase — future"
- Update gap-analysis with sprint completion tracking and closure entries
- Add Source column to requirements catalog for tracking requirement origins

## Type of Change
- [x] Documentation

## Changes
- `docs/designs/gap-analysis.md` — Updated completion tracking, CLI pattern refs, operator terminology
- `docs/designs/node-lifecycle.md` — Updated CLI examples to verb pattern
- `docs/designs/node-orchestration.md` — Updated CLI examples, operator refs, config phase language
- `docs/designs/phase-interfaces.md` — Updated CLI pattern references
- `docs/designs/requirements-catalog.md` — Updated REQ-ORC-003, added Source column schema
- `docs/designs/test-strategy.md` — Updated Blocks fields, validate commands, config phase refs

## Testing
- Documentation only, no code changes

## Related Issues
Follow-up from Sprint: Lifecycle Decomposition (iac-driver#146)
Aligns with iac-driver#144 (operator), iac-driver#145 (scenario retirement)

## Checklist
- [x] No stale `--manifest X --action Y` references remain
- [x] No premature `homestak config` references remain
- [x] "manifest executor" replaced with "operator" throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)