### PR TITLE
docs: Add epic template and standardize sprint cross-references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,6 +403,7 @@ Reusable templates in [docs/templates/](docs/templates/):
 |------|---------|
 | [aar.md](docs/templates/aar.md) | After Action Report template |
 | [retrospective.md](docs/templates/retrospective.md) | Sprint retrospective template |
+| [epic-issue.md](docs/templates/epic-issue.md) | Epic issue template |
 | [release-issue.md](docs/templates/release-issue.md) | Release planning issue template |
 | [design-summary.md](docs/templates/design-summary.md) | Design documentation templates |
 

--- a/docs/ISSUE-GUIDELINES.md
+++ b/docs/ISSUE-GUIDELINES.md
@@ -11,6 +11,14 @@ Actual work items representing bugs, enhancements, or features:
 - Assigned to sprints or worked directly on trunk
 - Closed when work is complete
 
+### Epic Issues
+
+Track multi-issue efforts requiring breakdown (see [epic-issue.md](templates/epic-issue.md)):
+- Use `epic` label
+- Track phased implementation, sub-tasks, design decisions
+- Reference sprint tracking issues by number, not ordinal (e.g., `#146` not "Sprint 1")
+- Link to design docs in `docs/designs/`
+
 ### Sprint Issues
 
 Track multi-issue coordinated work (see [10-sprint-planning.md](lifecycle/10-sprint-planning.md)):

--- a/docs/designs/gap-analysis.md
+++ b/docs/designs/gap-analysis.md
@@ -72,7 +72,7 @@ Identified issues in existing design documents that should be corrected.
 
 ## Code/Structure Cleanup Candidates
 
-Items identified during Sprint 0 analysis for NFR (Non-Functional Requirements) cleanup. These don't block functionality but improve maintainability.
+Items identified during iac-driver#141 analysis for NFR (Non-Functional Requirements) cleanup. These don't block functionality but improve maintainability.
 
 ### Scenario Naming (iac-driver)
 
@@ -111,24 +111,25 @@ Items identified during Sprint 0 analysis for NFR (Non-Functional Requirements) 
 
 Track progress on closing design gaps.
 
-| Gap | Target Sprint | Status | Notes |
-|-----|--------------|--------|-------|
-| unified-controller (#148) | Sprint 1 (#146) | **Complete** | Delivered in PR #150, #148 closed |
-| config-apply.md | Sprint 4 (iac-driver#147) | Not started | Blocks first "platform ready" |
-| manifest-schema-v2.md | Sprint 2 (#143) | Not started | Blocks operator (#144) |
-| scenario-consolidation.md | Sprint 5 (#145) | Not started | Transitional, archive after |
-| phase-interfaces.md | Sprint 0 | **Complete** | Resolved Q1-Q6, documented all phase contracts |
-| node-orchestration.md CLI examples | Sprint 0 | **Complete** | Updated to verb-based `./run.sh create/destroy/test` |
-| node-lifecycle.md phase-interfaces ref | Sprint 0 | **Complete** | Added cross-reference |
-| CLI verb pattern update | Sprint 0 | **Complete** | All design docs updated from `--manifest X --action Y` to verb subcommands |
-| requirements-catalog.md Source column | Sprint 0 | **Complete** | Added Source tracking, 11 implicit requirements |
-| requirements-catalog.md CTL category | Sprint 1 | **Complete** | Added controller requirements (REQ-CTL-001 to 010) |
-| Terminology standardization | Sprint 0 | **Complete** | "spec server" not "config server" |
+| Gap | Target | Status | Notes |
+|-----|--------|--------|-------|
+| unified-controller (#148) | iac-driver#146 | **Complete** | Delivered in PR #150, #148 closed |
+| config-apply.md | iac-driver#147 | Not started | Blocks first "platform ready" |
+| manifest-schema-v2.md | iac-driver#143 | Not started | Part of manifest operator sprint (#143 + #144) |
+| scenario-consolidation.md | iac-driver#145 | Not started | Transitional, archive after |
+| phase-interfaces.md | iac-driver#141 | **Complete** | Resolved Q1-Q6, documented all phase contracts |
+| node-orchestration.md CLI examples | iac-driver#141 | **Complete** | Updated to verb-based `./run.sh create/destroy/test` |
+| node-lifecycle.md phase-interfaces ref | iac-driver#141 | **Complete** | Added cross-reference |
+| CLI verb pattern update | iac-driver#141 | **Complete** | All design docs updated from `--manifest X --action Y` to verb subcommands |
+| requirements-catalog.md Source column | iac-driver#141 | **Complete** | Added Source tracking, 11 implicit requirements |
+| requirements-catalog.md CTL category | iac-driver#146 | **Complete** | Added controller requirements (REQ-CTL-001 to 010) |
+| Terminology standardization | iac-driver#141 | **Complete** | "spec server" not "config server" |
 
 ## Changelog
 
 | Date | Change |
 |------|--------|
+| 2026-02-05 | Replace ordinal sprint labels with issue references; update for #143+#144 combination |
 | 2026-02-05 | Updated CLI pattern references to verb-based subcommands; marked #148 complete; updated scenario retirement targets |
 | 2026-02-05 | Added unified controller (#148) to gap tracking; added CTL category to requirements |
 | 2026-02-04 | Updated Sprint 4 to reference iac-driver#147 (config phase) |

--- a/docs/designs/node-orchestration.md
+++ b/docs/designs/node-orchestration.md
@@ -314,7 +314,7 @@ nodes:
 
 ### Simplified CLI
 
-With topology and execution mode externalized to the manifest, the CLI uses verb subcommands (established in Sprint 1):
+With topology and execution mode externalized to the manifest, the CLI uses verb subcommands (established in iac-driver#146):
 
 ```bash
 # Legacy: scenario name encodes action + topology style

--- a/docs/designs/test-strategy.md
+++ b/docs/designs/test-strategy.md
@@ -37,7 +37,7 @@ This document defines the test hierarchy for homestak's lifecycle architecture, 
 
 **Total:** 12 files, ~5,500 lines (including conftest.py)
 
-**Sprint 1 additions (unified controller):**
+**Unified controller additions (iac-driver#146):**
 | File | Lines | Coverage Focus |
 |------|-------|----------------|
 | `test_ctrl_server.py` | ~400 | HTTPS server, daemon lifecycle, signals |
@@ -49,7 +49,7 @@ This document defines the test hierarchy for homestak's lifecycle architecture, 
 | `test_spec_resolver.py` | ~400 | SpecResolver (migrated from bootstrap) |
 | `test_spec_client.py` | ~300 | HTTP client, error handling, state |
 
-**Sprint 1 total:** +2,700 lines, 8 new files
+**iac-driver#146 total:** +2,700 lines, 8 new files
 
 **Target coverage for new lifecycle/ components:**
 - `lifecycle/core/create.py` - Create phase orchestration
@@ -76,7 +76,7 @@ This document defines the test hierarchy for homestak's lifecycle architecture, 
 | `bootstrap-install` | bootstrap + validation | ~2m |
 | `packer-build` | packer + QEMU | ~3m |
 
-**Sprint 1 additions:**
+**Unified controller additions (iac-driver#146):**
 | Scenario | Components Tested | Duration |
 |----------|-------------------|----------|
 | `controller-repos` | controller + git clone | ~30s |
@@ -357,22 +357,22 @@ Manifest:
 
 ## Mapping to Current Scenarios
 
-| System Test | Current Equivalent | Gap | Sprint |
-|-------------|-------------------|-----|--------|
-| ST-1 | `vm-rt` | Missing full config phase | Sprint 4 (#147) |
-| ST-2 | `vm-roundtrip` | No manifest, hardcoded in scenario | Sprint 3 (#144) |
-| ST-3 | `nested-pve-roundtrip` | No manifest, hardcoded 2-level | Sprint 3 (#144) |
-| ST-4 | `recursive-pve-roundtrip --manifest n3-full` | Close, but uses old CLI | Sprint 3 (#144) |
-| ST-5 | None | New capability (mixed execution modes) | Sprint 3 (#144) |
-| ST-6 | None | New capability (parallel peer creation) | Sprint 3 (#144) |
-| ST-7 | None | New capability (manifest validation) | Sprint 2 (#143) |
+| System Test | Current Equivalent | Gap | Blocked By |
+|-------------|-------------------|-----|------------|
+| ST-1 | `vm-rt` | Missing full config phase | iac-driver#147 |
+| ST-2 | `vm-roundtrip` | No manifest, hardcoded in scenario | iac-driver#143, #144 |
+| ST-3 | `nested-pve-roundtrip` | No manifest, hardcoded 2-level | iac-driver#143, #144 |
+| ST-4 | `recursive-pve-roundtrip --manifest n3-full` | Close, but uses old CLI | iac-driver#143, #144 |
+| ST-5 | None | New capability (mixed execution modes) | iac-driver#143, #144 |
+| ST-6 | None | New capability (parallel peer creation) | iac-driver#143, #144 |
+| ST-7 | None | New capability (manifest validation) | iac-driver#143, #144 |
 | ST-8 | Partial | Scenarios are mostly idempotent but not formally tested | Core |
 
-### Sprint 1 Contribution to System Tests
+### Unified Controller (iac-driver#146) Contribution to System Tests
 
-Sprint 1 (unified controller, #148) **enables** multiple system tests:
+The unified controller sprint (iac-driver#146) **enables** multiple system tests:
 
-| System Test | Sprint 1 Contribution |
+| System Test | Contribution |
 |-------------|----------------------|
 | ST-1 | Spec server infrastructure (controller/specs.py) |
 | ST-2 | Repos serving for push execution (controller/repos.py) |
@@ -436,8 +436,9 @@ pytest tests/test_config_resolver.py -k "test_resolve_env"  # Specific test
 
 | Date | Change |
 |------|--------|
+| 2026-02-05 | Replace ordinal sprint labels with issue references; update for #143+#144 combination |
 | 2026-02-05 | Updated CLI references to verb-based subcommands; updated ST-7 validate commands |
 | 2026-02-05 | Added test_controller_tls.py for TLS requirements; updated line counts |
-| 2026-02-05 | Added Sprint 1 unit tests (controller, resolver); added controller-repos scenario; mapped ST gaps to sprints |
-| 2026-02-04 | Renamed spec-vm-roundtrip → vm-rt; updated ST-1 gap to reference Sprint 4 #147 |
+| 2026-02-05 | Added unified controller unit tests (iac-driver#146); added controller-repos scenario; mapped ST gaps to scope issues |
+| 2026-02-04 | Renamed spec-vm-roundtrip → vm-rt; updated ST-1 gap to reference iac-driver#147 |
 | 2026-02-03 | Initial document |

--- a/docs/templates/epic-issue.md
+++ b/docs/templates/epic-issue.md
@@ -1,0 +1,58 @@
+# Epic Issue Template
+
+Create a new issue using this template.
+
+**Title format:** `Epic: {Theme}`
+
+Examples:
+- `Epic: CI/CD strategy`
+- `Epic: Manifest-based Orchestration Architecture`
+
+---
+
+## Overview
+
+{1-2 sentence summary of the epic's purpose and scope.}
+
+**Design doc:** {link to primary design document, if any}
+
+## Vision
+
+{Brief description of the end state. Diagrams or tables encouraged.}
+
+## Phased Implementation
+
+Track phases and their sprint issues. Reference sprint tracking issues by number when they exist; leave the Sprint cell empty until a sprint is planned.
+
+| Phase | Issues | Sprint | Scope | Status |
+|-------|--------|--------|-------|--------|
+| 1 | #N | #M | {scope summary} | {status} |
+| 2 | #N | | {scope summary} | Blocked on Phase 1 |
+
+**Status values:** Complete, Active, Planned, Blocked on Phase N, Independent
+
+## Sub-tasks
+
+- [ ] #N - {description} ({sprint issue ref if exists})
+- [ ] #M - {description}
+
+## Related Issues
+
+| Issue | Disposition |
+|-------|-------------|
+| #N | {how this issue relates: expanded, superseded, independent, etc.} |
+
+## Design Decisions
+
+- **{Decision}**: {rationale}
+
+<!--
+Tips:
+- Epics track multi-issue efforts requiring breakdown
+- Apply the `epic` label
+- Use scope issues for individual work items (<Verb> <what> format)
+- Use sprint issues (Sprint: <Theme>) for coordinated execution
+- Cross-reference sprint tracking issues by number, not ordinal (e.g., "#146" not "Sprint 1")
+- Keep the Phased Implementation table updated as work progresses
+- Link to design docs in docs/designs/ for architectural context
+-->


### PR DESCRIPTION
## Summary

- Add `docs/templates/epic-issue.md` — template for epic issues with phased implementation table pattern
- Add Epic Issues section to `docs/ISSUE-GUIDELINES.md` with cross-referencing convention
- Replace ordinal sprint labels ("Sprint 1", "Sprint 2") with issue references (`iac-driver#146`, `iac-driver#143`) across design docs
- Update design docs for iac-driver #143+#144 combination into single sprint
- Add epic template to `CLAUDE.md` documentation index

## Test plan

- [ ] Verify epic template renders correctly on GitHub
- [ ] Verify issue references in design docs resolve to correct iac-driver issues
- [ ] Verify ISSUE-GUIDELINES.md epic section is consistent with existing Sprint/Release sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)